### PR TITLE
시스템 메세지 색깔 추가

### DIFF
--- a/src/main/java/teamuni/net/autoannounce/autoannounce.java
+++ b/src/main/java/teamuni/net/autoannounce/autoannounce.java
@@ -57,14 +57,14 @@ public final class autoannounce extends JavaPlugin {
                 try {
                     i = Long.parseLong(arg1);
                 } catch (Exception e) {
-                    sender.sendMessage("잘못된 숫자입니다");
+                    sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.RED + "잘못된 숫자입니다!" + ChatColor.RESET);
                     return true;
                 }
                 getConfig().set("delay", i);
                 saveConfig();
                 delay = i;
                 updateRunnable();
-                player.sendMessage("딜레이를 설정하였습니다!");
+                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "딜레이를 설정했습니다!" + ChatColor.RESET);
                 break;
             }
             case "message": {
@@ -72,11 +72,11 @@ public final class autoannounce extends JavaPlugin {
                 getConfig().set("message", str);
                 saveConfig();
                 msg = str;
-                sender.sendMessage("공지를 수정했습니다!");
+                sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "공지를 수정했습니다!" + ChatColor.RESET);
             }
             default: {
-                player.sendMessage("/autoannounce delay [딜레이] - 딜레이를 설정합니다. [20 = 1초]");
-                player.sendMessage("/autoannounce message [공지] - 공지를 수정합니다.");
+                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce delay [딜레이]" + ChatColor.GRAY + "- 딜레이를 설정합니다. [20 = 1초]" + ChatColor.RESET);
+                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce message [공지]" + ChatColor.GRAY + "- 공지를 수정합니다." + ChatColor.RESET);
                 break;
             }
         }

--- a/src/main/java/teamuni/net/autoannounce/autoannounce.java
+++ b/src/main/java/teamuni/net/autoannounce/autoannounce.java
@@ -48,7 +48,11 @@ public final class autoannounce extends JavaPlugin {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
         Player player = (Player) sender;
-        if (args.length < 2) return true;
+        if (args.length < 2) {
+            sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + " /autoannounce delay [딜레이]" + ChatColor.GRAY + " - 딜레이를 설정합니다. [20 = 1초]");
+            sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + " /autoannounce message [공지]" + ChatColor.GRAY + " - 공지를 수정합니다.");
+            return true;
+        }
         String arg0 = args[0].toLowerCase();
         String arg1 = args[1];
         switch (arg0) {
@@ -57,14 +61,14 @@ public final class autoannounce extends JavaPlugin {
                 try {
                     i = Long.parseLong(arg1);
                 } catch (Exception e) {
-                    sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.RED + "잘못된 숫자입니다!");
+                    sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.RED + " 잘못된 숫자입니다!");
                     return true;
                 }
                 getConfig().set("delay", i);
                 saveConfig();
                 delay = i;
                 updateRunnable();
-                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "딜레이를 설정했습니다!");
+                sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + " 딜레이를 설정했습니다!");
                 break;
             }
             case "message": {
@@ -72,11 +76,7 @@ public final class autoannounce extends JavaPlugin {
                 getConfig().set("message", str);
                 saveConfig();
                 msg = str;
-                sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "공지를 수정했습니다!");
-            }
-            default: {
-                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce delay [딜레이]" + ChatColor.GRAY + "- 딜레이를 설정합니다. [20 = 1초]");
-                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce message [공지]" + ChatColor.GRAY + "- 공지를 수정합니다.");
+                sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + " 공지를 수정했습니다!");
                 break;
             }
         }

--- a/src/main/java/teamuni/net/autoannounce/autoannounce.java
+++ b/src/main/java/teamuni/net/autoannounce/autoannounce.java
@@ -57,14 +57,14 @@ public final class autoannounce extends JavaPlugin {
                 try {
                     i = Long.parseLong(arg1);
                 } catch (Exception e) {
-                    sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.RED + "잘못된 숫자입니다!" + ChatColor.RESET);
+                    sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.RED + "잘못된 숫자입니다!");
                     return true;
                 }
                 getConfig().set("delay", i);
                 saveConfig();
                 delay = i;
                 updateRunnable();
-                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "딜레이를 설정했습니다!" + ChatColor.RESET);
+                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "딜레이를 설정했습니다!");
                 break;
             }
             case "message": {
@@ -72,11 +72,11 @@ public final class autoannounce extends JavaPlugin {
                 getConfig().set("message", str);
                 saveConfig();
                 msg = str;
-                sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "공지를 수정했습니다!" + ChatColor.RESET);
+                sender.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "공지를 수정했습니다!");
             }
             default: {
-                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce delay [딜레이]" + ChatColor.GRAY + "- 딜레이를 설정합니다. [20 = 1초]" + ChatColor.RESET);
-                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce message [공지]" + ChatColor.GRAY + "- 공지를 수정합니다." + ChatColor.RESET);
+                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce delay [딜레이]" + ChatColor.GRAY + "- 딜레이를 설정합니다. [20 = 1초]");
+                player.sendMessage(ChatColor.BLUE + "[" + ChatColor.WHITE + " AutoAnnounce " + ChatColor.BLUE + "]" + ChatColor.GOLD + "/autoannounce message [공지]" + ChatColor.GRAY + "- 공지를 수정합니다.");
                 break;
             }
         }


### PR DESCRIPTION
플러그인 Prefix는 &9[ &f플러그인 이름 &9]
플러그인 명령어 설명같은경우, 
&9[ &f플러그인 이름 &9] &6/명령어 &7- 명령어의 설명

플러그인의 경고문 같은경우, [ex : 숫자를 적어야하는데 다른것을 적었을 경우]
&9[ &f플러그인 이름 &9] &c숫자를 입력하셔야합니다!

로 시스템 메세지 색깔을 추가했습니다.